### PR TITLE
Added resize delay for the rendering method

### DIFF
--- a/src/GLWpfControl/GLWpfControl.xaml.cs
+++ b/src/GLWpfControl/GLWpfControl.xaml.cs
@@ -17,6 +17,8 @@ namespace GLWpfControl {
     /// </summary>
     public sealed partial class GLWpfControl {
 
+        private static readonly int _resizeUpdateInterval = 100;
+
         private readonly Stopwatch _stopwatch = Stopwatch.StartNew();
         private long _resizeStartStamp;
 
@@ -79,8 +81,9 @@ namespace GLWpfControl {
             };
 
             SizeChanged += (sender, args) => {
-                if (_renderer == null)
+                if (_renderer == null) {
                     return;
+                }
 
                 _resizeStartStamp = _stopwatch.ElapsedMilliseconds;
             };
@@ -88,9 +91,10 @@ namespace GLWpfControl {
 
         private void OnCompTargetRender(object sender, EventArgs e) {
 
-            if (_resizeStartStamp != 0)
-            {
-                if (_resizeStartStamp + 100 > _stopwatch.ElapsedMilliseconds) return;
+            if (_resizeStartStamp != 0) {
+                if (_resizeStartStamp + _resizeUpdateInterval > _stopwatch.ElapsedMilliseconds) {
+                    return;
+                }
 
                 _renderer.DeleteBuffers();
                 var width = (int) ActualWidth;

--- a/src/GLWpfControlExample/MainWindow.xaml.cs
+++ b/src/GLWpfControlExample/MainWindow.xaml.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Diagnostics;
+using System.Windows;
 using GLWpfControl;
 using OpenTK;
 using OpenTK.Graphics;
@@ -9,7 +10,7 @@ namespace GLWpfControlExample {
     /// <summary>
     /// Interaction logic for MainWindow.xaml
     /// </summary>
-    public sealed partial class MainWindow {
+    public sealed partial class MainWindow : Window {
         private readonly Stopwatch _stopwatch = Stopwatch.StartNew();
 
         public MainWindow() {


### PR DESCRIPTION
When the GLWpfControl is being resized, it stops rendering and starts again after 1ms, to avoid lags and save performance