### PR TITLE
WIP Handling of device pixels and viewport pixels

### DIFF
--- a/src/GLWpfControl/GLWpfControl.cs
+++ b/src/GLWpfControl/GLWpfControl.cs
@@ -73,6 +73,14 @@ namespace OpenTK.Wpf
             set => _settings.RenderContinuously = value;
         }
 
+        /// Pixel size of the underlying OpenGL framebuffer.
+        /// It could differ from UIElement.RenderSize if UseDeviceDpi setting is set.
+        /// To be used for operations related to OpenGL viewport calls (glViewport, glScissor, ...).
+        public Size FramebufferSize {
+            get; 
+            private set; 
+        }
+
         /// <summary>
         ///     Used to create a new control. Before rendering can take place, <see cref="Start(GLWpfControlSettings)"/> must be called.
         /// </summary>
@@ -127,6 +135,8 @@ namespace OpenTK.Wpf
                 _imageRectangle = new Rect(0, 0, RenderSize.Width, RenderSize.Height);
                 _translateTransform = new TranslateTransform(0, RenderSize.Height);
                 _flipYTransform = new ScaleTransform(1, -1);
+
+                FramebufferSize = new Size(deviceWidth, deviceHeight);
             }
 
             if (_renderer != null && _context != null) {
@@ -241,6 +251,8 @@ namespace OpenTK.Wpf
 
                 var deviceSize = GetDevicePixelSize(_imageRectangle.Width, _imageRectangle.Height);
                 _renderer = new GLWpfControlRendererDx((int)deviceSize.Width, (int)deviceSize.Height, _d3dImage, _hasSyncFenceAvailable);
+
+                FramebufferSize = new Size((int)deviceSize.Width, (int)deviceSize.Height);
 
                 InvalidateVisual();
             }

--- a/src/GLWpfControl/GLWpfControl.cs
+++ b/src/GLWpfControl/GLWpfControl.cs
@@ -53,7 +53,7 @@ namespace OpenTK.Wpf
         public event Action Ready;
 
         // The image that the control uses to update stuff
-        private readonly D3DImage _d3dImage;
+        private D3DImage _d3dImage;
 
         // Transformations and size 
         private Rect _imageRectangle;
@@ -77,7 +77,6 @@ namespace OpenTK.Wpf
         ///     Used to create a new control. Before rendering can take place, <see cref="Start(GLWpfControlSettings)"/> must be called.
         /// </summary>
         public GLWpfControl() {
-            _d3dImage = new D3DImage(96, 96);
         }
 
         /// Starts the control and rendering, using the settings provided.
@@ -113,11 +112,21 @@ namespace OpenTK.Wpf
             }
 
             // if we actually have a surface we can render onto...
-            var shouldSetupRenderer = RenderSize.Width > 0 && RenderSize.Height > 0;
+            var presentationSource = PresentationSource.FromVisual(this);
+            var shouldSetupRenderer = RenderSize.Width > 0 && RenderSize.Height > 0 && presentationSource != null;
             if (shouldSetupRenderer) {
-                var width = (int) RenderSize.Width;
-                var height = (int) RenderSize.Height;
-                _renderer = new GLWpfControlRendererDx(width, height, _d3dImage, _hasSyncFenceAvailable);
+                var transformToDevice = presentationSource.CompositionTarget.TransformToDevice;
+
+                if(_d3dImage == null) {
+                    _d3dImage = new D3DImage(96.0 * transformToDevice.M11, 96.0 * transformToDevice.M22);
+                }
+
+                var deviceSize = GetDevicePixelSize(RenderSize.Width, RenderSize.Height);
+
+                var deviceWidth = (int)deviceSize.Width;
+                var deviceHeight = (int)deviceSize.Height;
+
+                _renderer = new GLWpfControlRendererDx(deviceWidth, deviceHeight, _d3dImage, _hasSyncFenceAvailable);
                 _imageRectangle = new Rect(0, 0, RenderSize.Width, RenderSize.Height);
                 _translateTransform = new TranslateTransform(0, RenderSize.Height);
                 _flipYTransform = new ScaleTransform(1, -1);
@@ -216,7 +225,10 @@ namespace OpenTK.Wpf
                 _imageRectangle.Height = info.NewSize.Height;
                 _translateTransform.Y = info.NewSize.Height;
                 _renderer.DeleteBuffers();
-                _renderer = new GLWpfControlRendererDx((int) _imageRectangle.Width, (int) _imageRectangle.Height, _d3dImage, _hasSyncFenceAvailable);
+
+                var deviceSize = GetDevicePixelSize(_imageRectangle.Width, _imageRectangle.Height);
+                _renderer = new GLWpfControlRendererDx((int)deviceSize.Width, (int)deviceSize.Height, _d3dImage, _hasSyncFenceAvailable);
+
                 InvalidateVisual();
             }
             base.OnRenderSizeChanged(info);
@@ -233,5 +245,20 @@ namespace OpenTK.Wpf
                 }
             }
         }
+
+        private Size GetDevicePixelSize(double width, double height)
+        {
+            // inspired from https://stackoverflow.com/questions/3286175/how-do-i-convert-a-wpf-size-to-physical-pixels
+            Matrix transformToDevice;
+            var source = PresentationSource.FromVisual(this);
+            if (source != null)
+                transformToDevice = source.CompositionTarget.TransformToDevice;
+            else
+                using (var s = new HwndSource(new HwndSourceParameters()))
+                    transformToDevice = s.CompositionTarget.TransformToDevice;
+
+            return (Size)transformToDevice.Transform(new Vector(width, height));
+        }
+
     }
 }

--- a/src/GLWpfControl/GLWpfControl.cs
+++ b/src/GLWpfControl/GLWpfControl.cs
@@ -115,10 +115,15 @@ namespace OpenTK.Wpf
             var presentationSource = PresentationSource.FromVisual(this);
             var shouldSetupRenderer = RenderSize.Width > 0 && RenderSize.Height > 0 && presentationSource != null;
             if (shouldSetupRenderer) {
-                var transformToDevice = presentationSource.CompositionTarget.TransformToDevice;
 
                 if(_d3dImage == null) {
-                    _d3dImage = new D3DImage(96.0 * transformToDevice.M11, 96.0 * transformToDevice.M22);
+                    if(_settings.UseDeviceDpi) {
+                        var transformToDevice = presentationSource.CompositionTarget.TransformToDevice;
+                        _d3dImage = new D3DImage(96.0 * transformToDevice.M11, 96.0 * transformToDevice.M22);
+                    }
+                    else {
+                        _d3dImage = new D3DImage(96.0, 96.0);
+                    }
                 }
 
                 var deviceSize = GetDevicePixelSize(RenderSize.Width, RenderSize.Height);
@@ -248,6 +253,10 @@ namespace OpenTK.Wpf
 
         private Size GetDevicePixelSize(double width, double height)
         {
+            if (!_settings.UseDeviceDpi) {
+                return new Size(width, height);
+            }
+
             // inspired from https://stackoverflow.com/questions/3286175/how-do-i-convert-a-wpf-size-to-physical-pixels
             Matrix transformToDevice;
             var source = PresentationSource.FromVisual(this);

--- a/src/GLWpfControl/GLWpfControl.cs
+++ b/src/GLWpfControl/GLWpfControl.cs
@@ -113,21 +113,13 @@ namespace OpenTK.Wpf
 
             // if we actually have a surface we can render onto...
             var presentationSource = PresentationSource.FromVisual(this);
+            // presentationSource must be checked for null: when the window is closed, IsVisibleChanged event is triggered
+            // and FromVisual method returns null due to disposal of visual.
             var shouldSetupRenderer = RenderSize.Width > 0 && RenderSize.Height > 0 && presentationSource != null;
-            if (shouldSetupRenderer) {
-
-                if(_d3dImage == null) {
-                    if(_settings.UseDeviceDpi) {
-                        var transformToDevice = presentationSource.CompositionTarget.TransformToDevice;
-                        _d3dImage = new D3DImage(96.0 * transformToDevice.M11, 96.0 * transformToDevice.M22);
-                    }
-                    else {
-                        _d3dImage = new D3DImage(96.0, 96.0);
-                    }
-                }
-
+            if (shouldSetupRenderer)
+            {
+                EnsureD3DImage(presentationSource);
                 var deviceSize = GetDevicePixelSize(RenderSize.Width, RenderSize.Height);
-
                 var deviceWidth = (int)deviceSize.Width;
                 var deviceHeight = (int)deviceSize.Height;
 
@@ -139,6 +131,22 @@ namespace OpenTK.Wpf
 
             if (_renderer != null && _context != null) {
                 Ready?.Invoke();
+            }
+        }
+
+        private void EnsureD3DImage(PresentationSource presentationSource)
+        {
+            if (_d3dImage == null)
+            {
+                if (_settings.UseDeviceDpi)
+                {
+                    var transformToDevice = presentationSource.CompositionTarget.TransformToDevice;
+                    _d3dImage = new D3DImage(96.0 * transformToDevice.M11, 96.0 * transformToDevice.M22);
+                }
+                else
+                {
+                    _d3dImage = new D3DImage(96.0, 96.0);
+                }
             }
         }
 

--- a/src/GLWpfControl/GLWpfControlSettings.cs
+++ b/src/GLWpfControl/GLWpfControlSettings.cs
@@ -6,6 +6,11 @@ namespace OpenTK.Wpf {
         /// Disable this if you want manual control over when the rendered surface is updated.
         public bool RenderContinuously = true;
 
+        /// If this is set to false, the control will render without any DPI scaling.
+        /// This will result in higher performance and a worse image quality on systems with >100% DPI settings, such as 'Retina' laptop screens with 4K UHD at small sizes.
+        /// This setting may be useful to get extra performance on mobile platforms.
+        public bool UseDeviceDpi = true;
+
         /// May be null. If defined, an external context will be used, of which the caller is responsible
         /// for managing the lifetime and disposal of.
         public IGraphicsContext ContextToUse { get; set; }
@@ -27,7 +32,8 @@ namespace OpenTK.Wpf {
                 GraphicsProfile = GraphicsProfile,
                 MajorVersion = MajorVersion,
                 MinorVersion = MinorVersion,
-                RenderContinuously = RenderContinuously
+                RenderContinuously = RenderContinuously,
+                UseDeviceDpi = UseDeviceDpi
             };
             return c;
         }


### PR DESCRIPTION
This PR aims to solve a mismatch between "viewport pixels" and "device pixels" while creating framebuffers for OpenGL and Direct3D.
At the moment, UIElement.RenderSize properties Width and Height are used for sizing framebuffers. Actually, they do not take into account that there are displays configured for higher pixel densities compared to the standard 96 dpi (think "retina" displays, or zoom > 100% configured in Display settings on Windows).
In this PR, OpenGL and Direct3D framebuffers will be sized to the actual device pixel size and not the viewport size, allowing for a sharper result on "retina" displays.
As an addition, I'm thinking of exposing the (actual) render width and height of the control as public properties, enabling the user to make correct calls to OpenGL that regard viewport size (glViewport, glScissor, ...).

Guys let me know what you think about this. Not 100% sure of what I've thought/written.

PS: I've really appreciated your efforts on porting OpenGL over WPF. Keep up this good work :)