### PR TITLE
Avoiding entire renderer instantiation after the resize of the control

### DIFF
--- a/src/GLWpfControl/GLWpfControl.cs
+++ b/src/GLWpfControl/GLWpfControl.cs
@@ -138,10 +138,10 @@ namespace OpenTK.Wpf
                 var deviceWidth = (int)deviceSize.Width;
                 var deviceHeight = (int)deviceSize.Height;
 
-                if (_renderer != null)
-                    _renderer.Resize(deviceWidth, deviceHeight);
-                else
-                    _renderer = new GLWpfControlRendererDx(deviceWidth, deviceHeight, _d3dImage, _hasSyncFenceAvailable);
+                if(_renderer == null)
+                    _renderer = new GLWpfControlRendererDx(_d3dImage, _hasSyncFenceAvailable);
+
+                _renderer.Resize(deviceWidth, deviceHeight);
 
                 FramebufferSize = new Size(deviceWidth, deviceHeight);
                 _imageRectangle = new Rect(0, 0, RenderSize.Width, RenderSize.Height);

--- a/src/GLWpfControl/GLWpfControl.cs
+++ b/src/GLWpfControl/GLWpfControl.cs
@@ -139,9 +139,10 @@ namespace OpenTK.Wpf
                 var deviceHeight = (int)deviceSize.Height;
 
                 if (_renderer != null)
-                    _renderer.DeleteBuffers();
+                    _renderer.Resize(deviceWidth, deviceHeight);
+                else
+                    _renderer = new GLWpfControlRendererDx(deviceWidth, deviceHeight, _d3dImage, _hasSyncFenceAvailable);
 
-                _renderer = new GLWpfControlRendererDx(deviceWidth, deviceHeight, _d3dImage, _hasSyncFenceAvailable);
                 FramebufferSize = new Size(deviceWidth, deviceHeight);
                 _imageRectangle = new Rect(0, 0, RenderSize.Width, RenderSize.Height);
                 _translateTransform.Y = RenderSize.Height;

--- a/src/GLWpfControl/GLWpfControl.cs
+++ b/src/GLWpfControl/GLWpfControl.cs
@@ -139,9 +139,11 @@ namespace OpenTK.Wpf
                 var deviceHeight = (int)deviceSize.Height;
 
                 if(_renderer == null)
+                {
                     _renderer = new GLWpfControlRendererDx(_d3dImage, _hasSyncFenceAvailable);
+                }
 
-                _renderer.Resize(deviceWidth, deviceHeight);
+                _renderer.SetRenderBufferSize(deviceWidth, deviceHeight);
 
                 FramebufferSize = new Size(deviceWidth, deviceHeight);
                 _imageRectangle = new Rect(0, 0, RenderSize.Width, RenderSize.Height);

--- a/src/GLWpfControl/GLWpfControlRendererDX.cs
+++ b/src/GLWpfControl/GLWpfControlRendererDX.cs
@@ -81,7 +81,9 @@ namespace OpenTK.Wpf {
         private void EnsureSurfaceCreated()
         {
             if (!recreatingSurfaceNeeded)
-                return; 
+            {
+                return;
+            }
 
             DeleteBuffers();
 
@@ -143,14 +145,21 @@ namespace OpenTK.Wpf {
             }
 
             if (_glFrameBuffer != 0)
+            {
                 GL.DeleteFramebuffer(_glFrameBuffer);
+            }
 
             if(_glDepthRenderBuffer != 0)
+            {
                 GL.DeleteRenderbuffer(_glDepthRenderBuffer);
+            }
+                
 
             if(_glSharedTexture != 0)
+            {
                 GL.DeleteTexture(_glSharedTexture);
-
+            }
+                
             _glFrameBuffer = 0;
             _glDepthRenderBuffer = 0;
             _glSharedTexture = 0;
@@ -158,7 +167,10 @@ namespace OpenTK.Wpf {
 
         public void UpdateImage() {
             if (_image == null)
+            {
                 return;
+            }
+                
 
             // // wait 10 seconds for the sync to complete.
             // if (_hasSyncFenceAvailable) {
@@ -198,10 +210,12 @@ namespace OpenTK.Wpf {
             // }
         }
 
-        public void Resize(int renderWidth, int renderHeight)
+        public void SetRenderBufferSize(int renderWidth, int renderHeight)
         {
             if (renderWidth == width && renderHeight == height)
+            {
                 return;
+            }
 
             width = renderWidth;
             height = renderHeight;

--- a/src/GLWpfControl/GLWpfControlRendererDX.cs
+++ b/src/GLWpfControl/GLWpfControlRendererDX.cs
@@ -30,11 +30,11 @@ namespace OpenTK.Wpf {
 
         public int FrameBuffer => _glFrameBuffer;
 
-        private int width;
-        private int height;
+        private int width = 1;
+        private int height = 1;
         private bool recreatingSurfaceNeeded = true;
 
-        public GLWpfControlRendererDx(int initialWidth, int initialHeight, D3DImage imageControl, bool hasSyncFenceAvailable) 
+        public GLWpfControlRendererDx(D3DImage imageControl, bool hasSyncFenceAvailable) 
         {
             // _wglInterop = new WGLInterop();
             _hasSyncFenceAvailable = hasSyncFenceAvailable;
@@ -76,11 +76,6 @@ namespace OpenTK.Wpf {
                 out _dxDeviceHandle);
 
             _glHandle = Wgl.DXOpenDeviceNV(_dxDeviceHandle);
-
-            width = initialWidth;
-            height = initialHeight;
-
-            EnsureSurfaceCreated();
         }
 
         private void EnsureSurfaceCreated()


### PR DESCRIPTION
This PR aims to avoid the need to the entire disposal of the renderer when the control resizes.

When resizing, the only important thing is to create a new rendertarget, along with the corresponding framebuffers (disposing old ones, of course). In fact, the d3d9 device can still be used again.

As a note, you can see that the BackbufferWidth and BackbufferHeight are set to 1. In fact, in this use case, the backbuffer is not used, as we're relying on the created rendertargets.