### PR TITLE
DPI scaling fix: content not covering all the available surface

### DIFF
--- a/src/GLWpfControl/DxGLFramebuffer.cs
+++ b/src/GLWpfControl/DxGLFramebuffer.cs
@@ -20,9 +20,15 @@ namespace OpenTK.Wpf {
         private DxGlContext DxGlContext { get; }
         
         /// The width of this buffer in pixels
-        public int Width { get; }
+        public int FramebufferWidth { get; }
         
         /// The height of this buffer in pixels
+        public int FramebufferHeight { get; }
+
+        /// The width of the element in device-independent pixels
+        public int Width { get; }
+
+        /// The height of the element in device-independent pixels
         public int Height { get; }
         
         /// The DirectX Render target (framebuffer) handle.
@@ -51,12 +57,14 @@ namespace OpenTK.Wpf {
             DxGlContext = context;
             Width = width;
             Height = height;
+            FramebufferWidth = (int)Math.Ceiling(width * dpiScaleX);
+            FramebufferHeight = (int)Math.Ceiling(height * dpiScaleY);
             
             var dxSharedHandle = IntPtr.Zero; // Unused windows-vista legacy sharing handle. Must always be null.
             DXInterop.CreateRenderTarget(
                 context.DxDeviceHandle,
-                Width,
-                Height,
+                FramebufferWidth,
+                FramebufferHeight,
                 Format.X8R8G8B8,// this is like A8 R8 G8 B8, but avoids issues with Gamma correction being applied twice.
                 MultisampleType.None,
                 0,
@@ -89,7 +97,7 @@ namespace OpenTK.Wpf {
 
             GLDepthRenderBufferHandle = GL.GenRenderbuffer();
             GL.BindRenderbuffer(RenderbufferTarget.Renderbuffer, GLDepthRenderBufferHandle);
-            GL.RenderbufferStorage(RenderbufferTarget.Renderbuffer, RenderbufferStorage.DepthComponent24, Width, Height);
+            GL.RenderbufferStorage(RenderbufferTarget.Renderbuffer, RenderbufferStorage.DepthComponent24, FramebufferWidth, FramebufferHeight);
             GL.FramebufferRenderbuffer(
                 FramebufferTarget.Framebuffer,
                 FramebufferAttachment.DepthAttachment,

--- a/src/GLWpfControl/GLWpfControlRenderer.cs
+++ b/src/GLWpfControl/GLWpfControlRenderer.cs
@@ -25,10 +25,10 @@ namespace OpenTK.Wpf
         public int FrameBufferHandle => _framebuffer.GLFramebufferHandle;
 
         /// The OpenGL Framebuffer width
-        public int Width => _framebuffer?.Width ?? 0;
+        public int Width => _framebuffer?.FramebufferWidth ?? 0;
         
         /// The OpenGL Framebuffer height
-        public int Height => _framebuffer?.Width ?? 0;
+        public int Height => _framebuffer?.FramebufferWidth ?? 0;
         
         private TimeSpan _lastFrameStamp;
 
@@ -81,7 +81,7 @@ namespace OpenTK.Wpf
             _framebuffer.D3dImage.Lock();
             Wgl.DXLockObjectsNV(_context.GlDeviceHandle, 1, new [] {_framebuffer.DxInteropRegisteredHandle});
             GL.BindFramebuffer(FramebufferTarget.Framebuffer, _framebuffer.GLFramebufferHandle);
-            GL.Viewport(0, 0, _framebuffer.Width, _framebuffer.Height);
+            GL.Viewport(0, 0, _framebuffer.FramebufferWidth, _framebuffer.FramebufferHeight);
         }
 
         /// Sets up the framebuffer and prepares stuff for usage in directx.
@@ -89,7 +89,7 @@ namespace OpenTK.Wpf
         {
             Wgl.DXUnlockObjectsNV(_context.GlDeviceHandle, 1, new [] {_framebuffer.DxInteropRegisteredHandle});
             _framebuffer.D3dImage.SetBackBuffer(D3DResourceType.IDirect3DSurface9, _framebuffer.DxRenderTargetHandle);
-            _framebuffer.D3dImage.AddDirtyRect(new Int32Rect(0, 0, _framebuffer.Width, _framebuffer.Height));
+            _framebuffer.D3dImage.AddDirtyRect(new Int32Rect(0, 0, _framebuffer.FramebufferWidth, _framebuffer.FramebufferHeight));
             _framebuffer.D3dImage.Unlock();
         }
     }


### PR DESCRIPTION
Fixes bug introduced in #24 

DXFramebufferWidth has now:
- Width and Height for device-independent pixels (1/96th of an inch) for rendering transformations in WPF
- FramebufferWidth and FramebufferHeight for the actual size of the framebuffer (they could be equal to Width and Height in case UseDeviceDpi is set to false)