### PR TITLE
Bugfix: resizing only width or height doesn't update the framebuffer

### DIFF
--- a/src/GLWpfControl/GLWpfControlRenderer.cs
+++ b/src/GLWpfControl/GLWpfControlRenderer.cs
@@ -68,7 +68,7 @@ namespace OpenTK.Wpf
             drawingContext.PushTransform(_framebuffer.FlipYTransform);                  // Apply a scale where the Y axis is -1. This will rotate the image by 180 deg
 
             // dpi scaled rectangle from the image
-            var rect = new Rect(0, 0, _framebuffer.Width, _framebuffer.Height);
+            var rect = new Rect(0, 0, _framebuffer.D3dImage.Width, _framebuffer.D3dImage.Height);
             drawingContext.DrawImage(_framebuffer.D3dImage, rect);            // Draw the image source 
 
             drawingContext.Pop();                                                       // Remove the scale transform

--- a/src/GLWpfControl/GLWpfControlRenderer.cs
+++ b/src/GLWpfControl/GLWpfControlRenderer.cs
@@ -40,7 +40,7 @@ namespace OpenTK.Wpf
 
 
         public void SetSize(int width, int height, double dpiScaleX, double dpiScaleY) {
-            if (_framebuffer == null || _framebuffer.Width != width && _framebuffer.Height != height) {
+            if (_framebuffer == null || _framebuffer.Width != width || _framebuffer.Height != height) {
                 _framebuffer?.Dispose();
                 _framebuffer = null;
                 if (width > 0 && height > 0) {
@@ -68,7 +68,7 @@ namespace OpenTK.Wpf
             drawingContext.PushTransform(_framebuffer.FlipYTransform);                  // Apply a scale where the Y axis is -1. This will rotate the image by 180 deg
 
             // dpi scaled rectangle from the image
-            var rect = new Rect(0, 0, _framebuffer.D3dImage.Width, _framebuffer.D3dImage.Height);
+            var rect = new Rect(0, 0, _framebuffer.Width, _framebuffer.Height);
             drawingContext.DrawImage(_framebuffer.D3dImage, rect);            // Draw the image source 
 
             drawingContext.Pop();                                                       // Remove the scale transform


### PR DESCRIPTION
Quite subtle bug resolved!

If one drags the window from the left or right side, a OnRenderSizeChanged event is triggered, but the framebuffer is not updated because of a small mistake in evaluating the condition for triggering the resize.

This leads to a wide white region appearing on the side of the control.