### PR TITLE
WIP support for multi-adapter d3d

### DIFF
--- a/src/GLWpfControl/DXGLContext.cs
+++ b/src/GLWpfControl/DXGLContext.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Windows;
 using System.Windows.Interop;
@@ -18,16 +20,16 @@ namespace OpenTK.Wpf {
         
         /// The directX context. This is basically the root of all DirectX state.
         public IntPtr DxContextHandle { get; }
-        
-        /// The directX device handle. This is the graphics card we're running on.
-        public IntPtr DxDeviceHandle { get; }
+
+        public D3DDevice Device { get; private set; }
+
+        private readonly uint _adapterCount;
+
+        private readonly List<D3DDevice> _devices;
         
         /// The OpenGL Context. This is basically the root of all OpenGL state.
         public IGraphicsContext GraphicsContext { get; }
         
-        /// An OpenGL handle to the DirectX device. Created and used by the WGL_dx_interop extension.
-        public IntPtr GlDeviceHandle { get; }
-
         /// The shared context we (may) want to lazily create/use.
         private static IGraphicsContext _sharedContext;
         private static GLWpfControlSettings _sharedContextSettings;
@@ -38,49 +40,27 @@ namespace OpenTK.Wpf {
 
 
         public DxGlContext([NotNull] GLWpfControlSettings settings) {
-            DXInterop.Direct3DCreate9Ex(DXInterop.DefaultSdkVersion, out var dxContextHandle);
-            DxContextHandle = dxContextHandle;
-
-            var deviceParameters = new PresentationParameters
-            {
-                Windowed = 1,
-                SwapEffect = SwapEffect.Discard,
-                DeviceWindowHandle = IntPtr.Zero,
-                PresentationInterval = 0,
-                BackBufferFormat = Format.X8R8G8B8, // this is like A8 R8 G8 B8, but avoids issues with Gamma correction being applied twice. 
-                BackBufferWidth = 1,
-                BackBufferHeight = 1,
-                AutoDepthStencilFormat = Format.Unknown,
-                BackBufferCount = 1,
-                EnableAutoDepthStencil = 0,
-                Flags = 0,
-                FullScreen_RefreshRateInHz = 0,
-                MultiSampleQuality = 0,
-                MultiSampleType = MultisampleType.None
-            };
-
-            DXInterop.CreateDeviceEx(
-                dxContextHandle,
-                0,
-                DeviceType.HAL, // use hardware rasterization
-                IntPtr.Zero,
-                CreateFlags.HardwareVertexProcessing |
-                CreateFlags.Multithreaded |
-                CreateFlags.PureDevice,
-                ref deviceParameters,
-                IntPtr.Zero,
-                out var dxDeviceHandle);
-            DxDeviceHandle = dxDeviceHandle;
-
+            
             // if the graphics context is null, we use the shared context.
-            if (settings.ContextToUse != null) {
+            if (settings.ContextToUse != null)
+            {
                 GraphicsContext = settings.ContextToUse;
             }
-            else {
+            else
+            {
                 GraphicsContext = GetOrCreateSharedOpenGLContext(settings);
             }
 
-            GlDeviceHandle = Wgl.DXOpenDeviceNV(dxDeviceHandle);
+            DXInterop.Direct3DCreate9Ex(DXInterop.DefaultSdkVersion, out var dxContextHandle);
+            DxContextHandle = dxContextHandle;
+
+            _adapterCount = DXInterop.GetAdapterCount(dxContextHandle);
+
+            _devices = Enumerable.Range(0, (int)_adapterCount)
+                .Select(i => D3DDevice.CreateDevice(dxContextHandle, i))
+                .ToList();
+
+            Device = _devices.First();
         }
 
         private static IGraphicsContext GetOrCreateSharedOpenGLContext(GLWpfControlSettings settings) {
@@ -128,6 +108,25 @@ namespace OpenTK.Wpf {
             }
             Interlocked.Increment(ref _sharedContextReferenceCount);
             return _sharedContext;
+        }
+
+        public void SetDeviceFromCurrentAdapter(Point point)
+        {
+            var monitor = User32Interop.MonitorFromPoint(new POINT((int)point.X, (int)point.Y), MonitorOptions.MONITOR_DEFAULTTONULL);
+            
+            D3DDevice dev = null;
+
+            for(int i = 0; i < _adapterCount; i++)
+            {
+                var d3dMonitor = DXInterop.GetAdapterMonitor(DxContextHandle, (uint)i);
+                if(d3dMonitor == monitor)
+                {
+                    dev = _devices[i];
+                    break;
+                }
+            }
+
+            Device = dev;
         }
 
         public void Dispose() {

--- a/src/GLWpfControl/DxGLFramebuffer.cs
+++ b/src/GLWpfControl/DxGLFramebuffer.cs
@@ -17,7 +17,7 @@ namespace OpenTK.Wpf {
     /// Prior to releasing references. 
     internal sealed class DxGLFramebuffer : IDisposable {
 
-        private DxGlContext DxGlContext { get; }
+        public D3DDevice Device { get; }
         
         /// The width of this buffer in pixels
         public int FramebufferWidth { get; }
@@ -46,6 +46,10 @@ namespace OpenTK.Wpf {
         /// Specific wgl_dx_interop handle that marks the framebuffer as ready for interop.
         public IntPtr DxInteropRegisteredHandle { get; }
 
+        public double DpiScaleX { get; }
+
+        public double DpiScaleY { get; }
+
         
         public D3DImage D3dImage { get; }
 
@@ -53,16 +57,19 @@ namespace OpenTK.Wpf {
         public ScaleTransform FlipYTransform { get; }
 
 
-        public DxGLFramebuffer([NotNull] DxGlContext context, int width, int height, double dpiScaleX, double dpiScaleY) {
-            DxGlContext = context;
+        public DxGLFramebuffer([NotNull] D3DDevice device, int width, int height, double dpiScaleX, double dpiScaleY) {
+            Device = device;
             Width = width;
             Height = height;
+            DpiScaleX = dpiScaleX;
+            DpiScaleY = dpiScaleY;
+
             FramebufferWidth = (int)Math.Ceiling(width * dpiScaleX);
             FramebufferHeight = (int)Math.Ceiling(height * dpiScaleY);
             
             var dxSharedHandle = IntPtr.Zero; // Unused windows-vista legacy sharing handle. Must always be null.
             DXInterop.CreateRenderTarget(
-                context.DxDeviceHandle,
+                device.Handle,
                 FramebufferWidth,
                 FramebufferHeight,
                 Format.X8R8G8B8,// this is like A8 R8 G8 B8, but avoids issues with Gamma correction being applied twice.
@@ -80,7 +87,7 @@ namespace OpenTK.Wpf {
             GLSharedTextureHandle = GL.GenTexture();
 
             var genHandle = Wgl.DXRegisterObjectNV(
-                context.GlDeviceHandle,
+                device.GLDeviceHandle,
                 dxRenderTargetHandle,
                 (uint)GLSharedTextureHandle,
                 (uint)TextureTarget.Texture2D,
@@ -118,7 +125,7 @@ namespace OpenTK.Wpf {
             GL.DeleteFramebuffer(GLFramebufferHandle);
             GL.DeleteRenderbuffer(GLDepthRenderBufferHandle);
             GL.DeleteTexture(GLSharedTextureHandle);
-            Wgl.DXUnregisterObjectNV(DxGlContext.GlDeviceHandle, DxInteropRegisteredHandle);
+            Wgl.DXUnregisterObjectNV(Device.GLDeviceHandle, DxInteropRegisteredHandle);
             DXInterop.Release(DxRenderTargetHandle);
         }
     }

--- a/src/GLWpfControl/GLWpfControl.cs
+++ b/src/GLWpfControl/GLWpfControl.cs
@@ -143,7 +143,7 @@ namespace OpenTK.Wpf
                 DesignTimeHelper.DrawDesignTimeHelper(this, drawingContext);
             }
             else {
-                _renderer?.Render(drawingContext);
+                _renderer?.Render(drawingContext, PointToScreen(new Point(0,0)));
             }
             base.OnRender(drawingContext);
         }

--- a/src/GLWpfControl/Interop/D3DDevice.cs
+++ b/src/GLWpfControl/Interop/D3DDevice.cs
@@ -1,0 +1,74 @@
+﻿using OpenTK.Graphics.Wgl;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace OpenTK.Wpf.Interop
+{
+    class D3DDevice : IDisposable
+    {
+
+        public IntPtr Handle { get; }
+
+        public IntPtr GLDeviceHandle { get; }
+
+        public int Adapter { get; }
+
+        private D3DDevice(IntPtr deviceHandle, int adapter, IntPtr glDeviceHandle)
+        {
+            Handle = deviceHandle;
+            Adapter = adapter;
+            GLDeviceHandle = glDeviceHandle;
+
+            IsDeviceValid();
+        }
+
+        public static D3DDevice CreateDevice(IntPtr contextHandle, int adapter)
+        {
+            var deviceParameters = new PresentationParameters
+            {
+                Windowed = 1,
+                SwapEffect = SwapEffect.Discard,
+                DeviceWindowHandle = IntPtr.Zero,
+                PresentationInterval = 0,
+                BackBufferFormat = Format.X8R8G8B8, // this is like A8 R8 G8 B8, but avoids issues with Gamma correction being applied twice. 
+                BackBufferWidth = 1,
+                BackBufferHeight = 1,
+                AutoDepthStencilFormat = Format.Unknown,
+                BackBufferCount = 1,
+                EnableAutoDepthStencil = 0,
+                Flags = 0,
+                FullScreen_RefreshRateInHz = 0,
+                MultiSampleQuality = 0,
+                MultiSampleType = MultisampleType.None
+            };
+
+            DXInterop.CreateDeviceEx(
+                contextHandle,
+                adapter,
+                DeviceType.HAL, // use hardware rasterization
+                IntPtr.Zero,
+                CreateFlags.HardwareVertexProcessing |
+                CreateFlags.Multithreaded |
+                CreateFlags.PureDevice,
+                ref deviceParameters,
+                IntPtr.Zero,
+                out var dxDeviceHandle);
+
+            var glDeviceHandle = Wgl.DXOpenDeviceNV(dxDeviceHandle);
+
+            return new D3DDevice(dxDeviceHandle, adapter, glDeviceHandle);
+        }
+
+        public bool IsDeviceValid()
+        {
+            return DXInterop.TestCooperativeLevel(Handle);
+        }
+
+        public void Dispose()
+        {
+            Wgl.DXCloseDeviceNV(Handle);
+            DXInterop.Release(Handle);
+        }
+    }
+}

--- a/src/GLWpfControl/Interop/DXInterop.cs
+++ b/src/GLWpfControl/Interop/DXInterop.cs
@@ -7,12 +7,18 @@ namespace OpenTK.Wpf.Interop
     {
         public const uint DefaultSdkVersion = 32;
         private const int CreateDeviceEx_Offset = 20;
+        private const int GetAdapterCount_Offset = 4;
         private const int CreateRenderTarget_Offset = 28;
+        private const int TestCooperativeLevel_Offset = 3;
         private const int Release_Offset = 2;
+        private const int GetAdapterMonitor_Offset = 15;
 
         private delegate int NativeCreateDeviceEx(IntPtr contextHandle, int adapter, DeviceType deviceType, IntPtr focusWindowHandle, CreateFlags behaviorFlags, ref PresentationParameters presentationParameters, IntPtr fullscreenDisplayMode, out IntPtr deviceHandle);
+        private delegate uint NativeGetAdapterCount(IntPtr contextHandle);
         private delegate int NativeCreateRenderTarget(IntPtr deviceHandle, int width, int height, Format format, MultisampleType multisample, int multisampleQuality, bool lockable, out IntPtr surfaceHandle, ref IntPtr sharedHandle);
         private delegate uint NativeRelease(IntPtr resourceHandle);
+        private delegate uint NativeTestCooperativeLevel(IntPtr deviceHandle);
+        private delegate IntPtr NativeGetAdapterMonitor(IntPtr contextHandle, uint index);
 
         [DllImport("d3d9.dll")]
         public static extern int Direct3DCreate9Ex(uint SdkVersion, out IntPtr ctx);
@@ -39,6 +45,32 @@ namespace OpenTK.Wpf.Interop
             IntPtr functionPointer = Marshal.ReadIntPtr(vTable, Release_Offset * IntPtr.Size);
             NativeRelease method = Marshal.GetDelegateForFunctionPointer<NativeRelease>(functionPointer);
             return method(resourceHandle);
+        }
+
+        public static uint GetAdapterCount(IntPtr contextHandle)
+        {
+            IntPtr vTable = Marshal.ReadIntPtr(contextHandle, 0);
+            IntPtr functionPointer = Marshal.ReadIntPtr(vTable, GetAdapterCount_Offset * IntPtr.Size);
+            NativeGetAdapterCount method = Marshal.GetDelegateForFunctionPointer<NativeGetAdapterCount>(functionPointer);
+            return method(contextHandle);
+        }
+
+        public static bool TestCooperativeLevel(IntPtr deviceHandle)
+        {
+            IntPtr vTable = Marshal.ReadIntPtr(deviceHandle, 0);
+            IntPtr functionPointer = Marshal.ReadIntPtr(vTable, TestCooperativeLevel_Offset * IntPtr.Size);
+            NativeTestCooperativeLevel method = Marshal.GetDelegateForFunctionPointer<NativeTestCooperativeLevel>(functionPointer);
+            var result = method(deviceHandle);
+
+            return result == 0;
+        }
+
+        public static IntPtr GetAdapterMonitor(IntPtr contextHandle, uint index)
+        {
+            IntPtr vTable = Marshal.ReadIntPtr(contextHandle, 0);
+            IntPtr functionPointer = Marshal.ReadIntPtr(vTable, GetAdapterMonitor_Offset * IntPtr.Size);
+            NativeGetAdapterMonitor method = Marshal.GetDelegateForFunctionPointer<NativeGetAdapterMonitor>(functionPointer);
+            return method(contextHandle, index);
         }
 
     }

--- a/src/GLWpfControl/Interop/User32Interop.cs
+++ b/src/GLWpfControl/Interop/User32Interop.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+using System.Text;
+
+namespace OpenTK.Wpf.Interop
+{
+    [StructLayout(LayoutKind.Sequential)]
+    public struct POINT
+    {
+        public int X;
+        public int Y;
+
+        public POINT(int x, int y)
+        {
+            this.X = x;
+            this.Y = y;
+        }
+
+        public static implicit operator System.Drawing.Point(POINT p)
+        {
+            return new System.Drawing.Point(p.X, p.Y);
+        }
+
+        public static implicit operator POINT(System.Drawing.Point p)
+        {
+            return new POINT(p.X, p.Y);
+        }
+    }
+
+    enum MonitorOptions : uint
+    {
+        MONITOR_DEFAULTTONULL = 0x00000000,
+        MONITOR_DEFAULTTOPRIMARY = 0x00000001,
+        MONITOR_DEFAULTTONEAREST = 0x00000002
+    }
+
+    static class User32Interop
+    {
+
+        [DllImport("user32.dll", SetLastError = true)]
+        public static extern IntPtr MonitorFromPoint(POINT pt, MonitorOptions dwFlags);
+
+    }
+}


### PR DESCRIPTION
Freely inspired from [an official guide from WPF that addresses the issue](https://docs.microsoft.com/en-us/dotnet/desktop/wpf/advanced/walkthrough-hosting-direct3d9-content-in-wpf?view=netframeworkdesktop-4.8
).

TODO:
- check if the general approach works
- if it works:
  - the selection of the correct device should not be in the render phase. It should be safe to do it periodically (in the link posted, it uses a timer that fires every 500 ms or so)
  - the adapter count is evaluated when instantiating the d3d context for the first time. Should we check periodically for adapter count changed (well, is it even possible)?
  - devices should be regularly checked for validity and cleaned up if they are not valid anymore (d3d device lost). In this case, everything (D3D context and all devices) must be recreated again. Methods for cleaning devices were added. (However this is more of general rather than tackling this specific issue and could be addressed in some other PR)
