### PR TITLE
Bugfix: update of RenderContinuously not working correctly

### DIFF
--- a/src/GLWpfControl/GLWpfControl.cs
+++ b/src/GLWpfControl/GLWpfControl.cs
@@ -133,8 +133,9 @@ namespace OpenTK.Wpf
         {
             if (_needsRedraw) {
                 InvalidateVisual();
-                _needsRedraw = RenderContinuously;
             }
+
+            _needsRedraw = RenderContinuously;
         }
 
         protected override void OnRender(DrawingContext drawingContext) {


### PR DESCRIPTION
Fixes bug in #26 : when RenderContinuously is updated from False to True, the control doesn't start drawing continuously.

Thanks Daniel for discovering this bug!