### PR TITLE
Bugfix for 3.x: resizing from one side of the control not working

### DIFF
--- a/src/GLWpfControl/GLWpfControlRenderer.cs
+++ b/src/GLWpfControl/GLWpfControlRenderer.cs
@@ -39,7 +39,7 @@ namespace OpenTK.Wpf
 
 
         public void SetSize(int width, int height, double dpiScaleX, double dpiScaleY) {
-            if (_framebuffer == null || _framebuffer.Width != width && _framebuffer.Height != height) {
+            if (_framebuffer == null || _framebuffer.Width != width || _framebuffer.Height != height) {
                 _framebuffer?.Dispose();
                 _framebuffer = null;
                 if (width > 0 && height > 0) {


### PR DESCRIPTION
Fixes bug #33 for 3.x version of the control.
The same bug for 4.x version was already been solved from PR #27 .