### PR TITLE
Safety checks improvement for checking Start() call

### DIFF
--- a/src/GLWpfControl/GLWpfControl.cs
+++ b/src/GLWpfControl/GLWpfControl.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.ComponentModel;
 using System.Diagnostics;
+using System.Globalization;
 using System.Windows;
 using System.Windows.Media;
 using JetBrains.Annotations;
@@ -156,9 +157,13 @@ namespace OpenTK.Wpf
             if (isDesignMode) {
                 DesignTimeHelper.DrawDesignTimeHelper(this, drawingContext);
             }
-            else {
-                _renderer?.Render(drawingContext);
+            else if(_renderer != null) {
+                _renderer.Render(drawingContext);
             }
+            else {
+                UnstartedControlHelper.DrawUnstartedControlHelper(this, drawingContext);
+            }
+
             base.OnRender(drawingContext);
         }
         

--- a/src/GLWpfControl/GLWpfControl.cs
+++ b/src/GLWpfControl/GLWpfControl.cs
@@ -18,19 +18,8 @@ namespace OpenTK.Wpf
         // EVENTS
         // -----------------------------------
 
-        private event Action<TimeSpan> InternalRender;
-
         /// Called whenever rendering should occur.
-        public event Action<TimeSpan> Render {
-            add
-            {
-                if (_settings == null) {
-                    throw new InvalidOperationException($"The {nameof(Render)} may only be bound after {nameof(Start)} has been called on this {nameof(GLWpfControl)}.");
-                }
-                InternalRender += value;
-            }
-            remove => InternalRender -= value;
-        }
+        public event Action<TimeSpan> Render;
 
         /// Called once per frame after render. This does not synchronize with the copy to the screen.
         /// This is only for extremely advanced use, where a non-display out task needs to run.
@@ -96,7 +85,7 @@ namespace OpenTK.Wpf
             _settings = settings.Copy();
             _needsRedraw = settings.RenderContinuously;
             _renderer = new GLWpfControlRenderer(_settings);
-            _renderer.GLRender += timeDelta => InternalRender?.Invoke(timeDelta);
+            _renderer.GLRender += timeDelta => Render?.Invoke(timeDelta);
             _renderer.GLAsyncRender += () => AsyncRender?.Invoke();
             IsVisibleChanged += (_, args) => {
                 if ((bool) args.NewValue) {

--- a/src/GLWpfControl/UnstartedControlHelper.cs
+++ b/src/GLWpfControl/UnstartedControlHelper.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Globalization;
+using System.Text;
+using System.Windows;
+using System.Windows.Media;
+
+namespace OpenTK.Wpf
+{
+    internal static class UnstartedControlHelper
+    {
+
+        public static void DrawUnstartedControlHelper(GLWpfControl control, DrawingContext drawingContext)
+        {
+            if (control.Visibility == Visibility.Visible && control.ActualWidth > 0 && control.ActualHeight > 0)
+            {
+                var width = control.ActualWidth;
+                var height = control.ActualHeight;
+                drawingContext.DrawRectangle(Brushes.Gray, null, new Rect(0, 0, width, height));
+
+                if(!Debugger.IsAttached) // Do not show the message if we're not debugging
+                {
+                    return;
+                }
+
+                const string unstartedLabelText = "OpenGL content. Call Start() on the control to begin rendering.";
+                const int size = 12;
+                var tf = new Typeface("Arial");
+#pragma warning disable 618
+                var ft = new FormattedText(unstartedLabelText, CultureInfo.InvariantCulture, FlowDirection.LeftToRight, tf, size, Brushes.White)
+                {
+                    TextAlignment = TextAlignment.Left,
+                    MaxTextWidth = width
+                };
+#pragma warning restore 618
+
+                drawingContext.DrawText(ft, new Point(0, 0));
+            }
+        }
+
+
+    }
+}


### PR DESCRIPTION
This PR:
- removes the idiot check, since it prevents the user to attach a Render callback on the XAML (the example is not broken anymore)
- shows a fallback view of the control if Start() is not called, reminding the user to call the Start() method (only when debugging)

This could be ground to other useful checks (eg: check if a Render callback is actually set).